### PR TITLE
[DK] Fix resource map returning wrong function

### DIFF
--- a/HeroLib/Class/Unit/Player/Power.lua
+++ b/HeroLib/Class/Unit/Player/Power.lua
@@ -745,7 +745,7 @@ do
     -- ComboPoints
     [4] = function() return Player:ComboPoints() end,
     -- Runes
-    [5] = function() return Player:Runes() end,
+    [5] = function() return Player:Rune() end,
     -- Runic Power
     [6] = function() return Player:RunicPower() end,
     -- Soul Shards


### PR DESCRIPTION
Function was changed in b6c88910725bb2c8dcaba6b23fb171de5087d5b1 this fixes it